### PR TITLE
Map `gray` and `light-gray` ANSI colors

### DIFF
--- a/colors/amberwood.kak
+++ b/colors/amberwood.kak
@@ -133,5 +133,5 @@ set-face global ts_type_enum_variant "magenta"
 set-face global ts_variable "%opt{fg}"
 set-face global ts_variable_builtin "%opt{bright_blue}"
 set-face global ts_variable_other ts_variable
-set-face global ts_variable_other_member "white"
-set-face global ts_variable_parameter "white+i"
+set-face global ts_variable_other_member "bright-white"
+set-face global ts_variable_parameter "bright-white+i"

--- a/colors/ayu-dark.kak
+++ b/colors/ayu-dark.kak
@@ -18,7 +18,7 @@ set-face global Default ",%opt{background}@Default"
 set-face global Default "%opt{foreground}@Default"
 
 # kak-tree-sitter
-set-face global ts_comment "gray+i"
+set-face global ts_comment "bright-black+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "magenta"

--- a/colors/ayu-evolve.kak
+++ b/colors/ayu-evolve.kak
@@ -12,7 +12,7 @@ set-face global Default ",%opt{background}@Default"
 set-face global Default "%opt{foreground}@Default"
 
 # kak-tree-sitter
-set-face global ts_comment "gray+i"
+set-face global ts_comment "bright-black+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "magenta"

--- a/colors/ayu-light.kak
+++ b/colors/ayu-light.kak
@@ -20,7 +20,7 @@ set-face global Default ",%opt{background}@Default"
 set-face global Default "%opt{foreground}@Default"
 
 # kak-tree-sitter
-set-face global ts_comment "gray+i"
+set-face global ts_comment "bright-black+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "magenta"

--- a/colors/ayu-mirage.kak
+++ b/colors/ayu-mirage.kak
@@ -18,7 +18,7 @@ set-face global Default ",%opt{background}@Default"
 set-face global Default "%opt{foreground}@Default"
 
 # kak-tree-sitter
-set-face global ts_comment "gray+i"
+set-face global ts_comment "bright-black+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "magenta"

--- a/colors/base16-terminal.kak
+++ b/colors/base16-terminal.kak
@@ -7,7 +7,7 @@ set-face global Default "@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "bright-gray+i"
+set-face global ts_comment "white+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "yellow"

--- a/colors/base16-transparent.kak
+++ b/colors/base16-transparent.kak
@@ -2,12 +2,12 @@
 
 # Standard Kakoune
 set-face global Default default,default,default
+set-face global Default "bright-white@Default"
 set-face global Default "white@Default"
-set-face global Default "bright-gray@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "bright-gray"
+set-face global ts_comment "white"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "yellow"

--- a/colors/curzon.kak
+++ b/colors/curzon.kak
@@ -43,7 +43,7 @@ set-face global Default "%opt{text}@Default"
 set-face global ts_comment "%opt{comment_color}+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
-set-face global ts_constant "white"
+set-face global ts_constant "bright-white"
 set-face global ts_constant_builtin ts_constant
 set-face global ts_constant_builtin_boolean ts_constant_builtin
 set-face global ts_constant_character ts_constant
@@ -57,8 +57,8 @@ set-face global ts_diff_delta "%opt{info}"
 set-face global ts_diff_delta_moved ts_diff_delta
 set-face global ts_diff_minus "rgb:F22C86"
 set-face global ts_diff_plus "rgb:35BF86"
-set-face global ts_function "white"
-set-face global ts_function_builtin "white"
+set-face global ts_function "bright-white"
+set-face global ts_function_builtin "bright-white"
 set-face global ts_function_macro "%opt{light_blue}"
 set-face global ts_function_method ts_function
 set-face global ts_function_special ts_function
@@ -125,12 +125,12 @@ set-face global ts_string_symbol ts_string
 set-face global ts_tag "%opt{tag}"
 set-face global ts_tag_error ts_tag
 set-face global ts_text_title ts_text
-set-face global ts_type "white"
-set-face global ts_type_builtin "white"
+set-face global ts_type "bright-white"
+set-face global ts_type_builtin "bright-white"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant ts_type_enum
 set-face global ts_variable "%opt{variable}"
 set-face global ts_variable_builtin "%opt{built_in}+bi"
 set-face global ts_variable_other ts_variable
-set-face global ts_variable_other_member "white"
+set-face global ts_variable_other_member "bright-white"
 set-face global ts_variable_parameter "%opt{variable}"

--- a/colors/darcula-solid.kak
+++ b/colors/darcula-solid.kak
@@ -8,7 +8,7 @@ declare-option str grey04 "rgb:A8A8A8"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",%opt{grey01}@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
@@ -19,7 +19,7 @@ set-face global ts_constant "%opt{lightblue}"
 set-face global ts_constant_builtin ts_constant
 set-face global ts_constant_builtin_boolean ts_constant_builtin
 set-face global ts_constant_character ts_constant
-set-face global ts_constant_character_escape "white"
+set-face global ts_constant_character_escape "bright-white"
 set-face global ts_constant_macro ts_constant
 set-face global ts_constant_numeric "%opt{lightblue}"
 set-face global ts_constant_numeric_float ts_constant_numeric
@@ -54,7 +54,7 @@ set-face global ts_keyword_storage_modifier_mut ts_keyword_storage_modifier
 set-face global ts_keyword_storage_modifier_ref ts_keyword_storage_modifier
 set-face global ts_keyword_storage_type ts_keyword_storage
 set-face global ts_label "%opt{purple}"
-set-face global ts_markup_bold "white+b"
+set-face global ts_markup_bold "bright-white+b"
 set-face global ts_markup_heading ts_markup
 set-face global ts_markup_heading_1 "%opt{orange}"
 set-face global ts_markup_heading_2 "yellow"
@@ -63,10 +63,10 @@ set-face global ts_markup_heading_4 "%opt{grey}"
 set-face global ts_markup_heading_5 "%opt{purple}"
 set-face global ts_markup_heading_6 "%opt{darkgreen}"
 set-face global ts_markup_heading_marker ts_markup_heading
-set-face global ts_markup_italic "white+i"
+set-face global ts_markup_italic "bright-white+i"
 set-face global ts_markup_link ts_markup
 set-face global ts_markup_link_label ts_markup_link
-set-face global ts_markup_link_text "white"
+set-face global ts_markup_link_text "bright-white"
 set-face global ts_markup_link_uri ts_markup_link
 set-face global ts_markup_link_url "%opt{lightblue}+u"
 set-face global ts_markup_list ts_markup
@@ -78,7 +78,7 @@ set-face global ts_markup_quote "%opt{darkgreen}"
 set-face global ts_markup_raw "%opt{purple}"
 set-face global ts_markup_raw_block ts_markup_raw
 set-face global ts_markup_raw_inline ts_markup_raw
-set-face global ts_markup_strikethrough "white+s"
+set-face global ts_markup_strikethrough "bright-white+s"
 set-face global ts_namespace "%opt{purple}+i"
 set-face global ts_operator "%opt{grey05}"
 set-face global ts_punctuation_bracket ts_punctuation
@@ -96,11 +96,11 @@ set-face global ts_string_symbol ts_string
 set-face global ts_tag "%opt{orange}"
 set-face global ts_tag_error ts_tag
 set-face global ts_text_title ts_text
-set-face global ts_type "white"
+set-face global ts_type "bright-white"
 set-face global ts_type_builtin "%opt{orange}"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant "%opt{orange}"
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin ts_variable
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "yellow"

--- a/colors/darcula.kak
+++ b/colors/darcula.kak
@@ -21,7 +21,7 @@ declare-option str blue "rgb:104158"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",%opt{grey01}@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
@@ -32,7 +32,7 @@ set-face global ts_constant "%opt{lightblue}"
 set-face global ts_constant_builtin ts_constant
 set-face global ts_constant_builtin_boolean ts_constant_builtin
 set-face global ts_constant_character ts_constant
-set-face global ts_constant_character_escape "white"
+set-face global ts_constant_character_escape "bright-white"
 set-face global ts_constant_macro ts_constant
 set-face global ts_constant_numeric "%opt{lightblue}"
 set-face global ts_constant_numeric_float ts_constant_numeric
@@ -67,7 +67,7 @@ set-face global ts_keyword_storage_modifier_mut ts_keyword_storage_modifier
 set-face global ts_keyword_storage_modifier_ref ts_keyword_storage_modifier
 set-face global ts_keyword_storage_type ts_keyword_storage
 set-face global ts_label "%opt{purple}"
-set-face global ts_markup_bold "white+b"
+set-face global ts_markup_bold "bright-white+b"
 set-face global ts_markup_heading ts_markup
 set-face global ts_markup_heading_1 "%opt{orange}"
 set-face global ts_markup_heading_2 "yellow"
@@ -76,10 +76,10 @@ set-face global ts_markup_heading_4 "%opt{grey}"
 set-face global ts_markup_heading_5 "%opt{purple}"
 set-face global ts_markup_heading_6 "%opt{darkgreen}"
 set-face global ts_markup_heading_marker ts_markup_heading
-set-face global ts_markup_italic "white+i"
+set-face global ts_markup_italic "bright-white+i"
 set-face global ts_markup_link ts_markup
 set-face global ts_markup_link_label ts_markup_link
-set-face global ts_markup_link_text "white"
+set-face global ts_markup_link_text "bright-white"
 set-face global ts_markup_link_uri ts_markup_link
 set-face global ts_markup_link_url "%opt{lightblue}+u"
 set-face global ts_markup_list ts_markup
@@ -91,7 +91,7 @@ set-face global ts_markup_quote "%opt{darkgreen}"
 set-face global ts_markup_raw "%opt{purple}"
 set-face global ts_markup_raw_block ts_markup_raw
 set-face global ts_markup_raw_inline ts_markup_raw
-set-face global ts_markup_strikethrough "white+s"
+set-face global ts_markup_strikethrough "bright-white+s"
 set-face global ts_namespace "%opt{purple}+i"
 set-face global ts_operator "%opt{grey05}"
 set-face global ts_punctuation_bracket ts_punctuation
@@ -109,11 +109,11 @@ set-face global ts_string_symbol ts_string
 set-face global ts_tag "%opt{orange}"
 set-face global ts_tag_error ts_tag
 set-face global ts_text_title ts_text
-set-face global ts_type "white"
+set-face global ts_type "bright-white"
 set-face global ts_type_builtin "%opt{orange}"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant "%opt{orange}"
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin ts_variable
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "yellow"

--- a/colors/dark-high-contrast.kak
+++ b/colors/dark-high-contrast.kak
@@ -18,10 +18,10 @@ declare-option str emerald_green "rgb:4EC9B0"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",black@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
-set-face global ts_comment "white"
+set-face global ts_comment "bright-white"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "%opt{aqua}"
@@ -89,7 +89,7 @@ set-face global ts_markup_raw_block ts_markup_raw
 set-face global ts_markup_raw_inline ts_markup_raw
 set-face global ts_markup_strikethrough "+s"
 set-face global ts_namespace "blue"
-set-face global ts_operator "white"
+set-face global ts_operator "bright-white"
 set-face global ts_punctuation_bracket ts_punctuation
 set-face global ts_punctuation_delimiter ts_punctuation
 set-face global ts_punctuation_special ts_punctuation

--- a/colors/doom-acario-dark.kak
+++ b/colors/doom-acario-dark.kak
@@ -23,7 +23,7 @@ set-face global Default "%opt{fg}@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "blue"
-set-face global ts_comment "gray+i"
+set-face global ts_comment "bright-black+i"
 set-face global ts_comment_block "green+i"
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "magenta"
@@ -43,7 +43,7 @@ set-face global ts_diff_plus "green"
 set-face global ts_function "yellow"
 set-face global ts_function_builtin "blue"
 set-face global ts_function_macro ts_function
-set-face global ts_function_method "white"
+set-face global ts_function_method "bright-white"
 set-face global ts_function_special ts_function
 set-face global ts_keyword "red"
 set-face global ts_keyword_conditional ts_keyword
@@ -90,10 +90,10 @@ set-face global ts_markup_raw ts_markup
 set-face global ts_markup_raw_block "green,%opt{base4}"
 set-face global ts_markup_raw_inline "green,%opt{base4}"
 set-face global ts_markup_strikethrough "+s"
-set-face global ts_namespace "white"
+set-face global ts_namespace "bright-white"
 set-face global ts_operator "blue"
 set-face global ts_punctuation_bracket "blue"
-set-face global ts_punctuation_delimiter "white+b"
+set-face global ts_punctuation_delimiter "bright-white+b"
 set-face global ts_punctuation_special ts_punctuation
 set-face global ts_special "%opt{orange}"
 set-face global ts_string "green"
@@ -115,4 +115,4 @@ set-face global ts_variable "cyan"
 set-face global ts_variable_builtin ts_variable
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member ts_variable_other
-set-face global ts_variable_parameter "white"
+set-face global ts_variable_parameter "bright-white"

--- a/colors/emacs.kak
+++ b/colors/emacs.kak
@@ -550,7 +550,7 @@ declare-option str gray100 "rgb:FFFFFF"
 
 # Standard Kakoune
 set-face global Default default,default,default
-set-face global Default "black,white@Default"
+set-face global Default "black,bright-white@Default"
 set-face global Default "black@Default"
 
 # kak-tree-sitter

--- a/colors/everblush.kak
+++ b/colors/everblush.kak
@@ -96,10 +96,10 @@ set-face global ts_markup_raw_block ts_markup_raw
 set-face global ts_markup_raw_inline ts_markup_raw
 set-face global ts_markup_strikethrough "+s"
 set-face global ts_namespace "%opt{red_light}"
-set-face global ts_operator "white"
-set-face global ts_punctuation_bracket "white"
-set-face global ts_punctuation_delimiter "white"
-set-face global ts_punctuation_special "white"
+set-face global ts_operator "bright-white"
+set-face global ts_punctuation_bracket "bright-white"
+set-face global ts_punctuation_delimiter "bright-white"
+set-face global ts_punctuation_special "bright-white"
 set-face global ts_special "%opt{red_light}"
 set-face global ts_string "green"
 set-face global ts_string_escape ts_string
@@ -116,7 +116,7 @@ set-face global ts_type "yellow"
 set-face global ts_type_builtin "yellow"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant ts_type_enum
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin "blue"
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "red"

--- a/colors/horizon-dark.kak
+++ b/colors/horizon-dark.kak
@@ -14,11 +14,11 @@ declare-option str blue "rgb:25B2BC"
 
 # Standard Kakoune
 set-face global Default default,default,default
-set-face global Default "gray,%opt{bg}@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-black,%opt{bg}@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
-set-face global ts_comment "bright-gray"
+set-face global ts_comment "white"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "%opt{purple}"
@@ -78,7 +78,7 @@ set-face global ts_markup_link_url ts_markup_link
 set-face global ts_markup_list ts_markup
 set-face global ts_markup_list_checked "green"
 set-face global ts_markup_list_numbered ts_markup_list
-set-face global ts_markup_list_unchecked "bright-gray"
+set-face global ts_markup_list_unchecked "white"
 set-face global ts_markup_list_unnumbered ts_markup_list
 set-face global ts_markup_quote "%opt{orange}"
 set-face global ts_markup_raw "%opt{orange}"

--- a/colors/jellybeans.kak
+++ b/colors/jellybeans.kak
@@ -77,7 +77,7 @@ set-face global ts_keyword_storage_modifier_mut ts_keyword_storage_modifier
 set-face global ts_keyword_storage_modifier_ref ts_keyword_storage_modifier
 set-face global ts_keyword_storage_type ts_keyword_storage
 set-face global ts_label "yellow"
-set-face global ts_markup_bold "white+b"
+set-face global ts_markup_bold "bright-white+b"
 set-face global ts_markup_heading "%opt{mid_blue}+b"
 set-face global ts_markup_heading_1 ts_markup_heading
 set-face global ts_markup_heading_2 ts_markup_heading

--- a/colors/meliora.kak
+++ b/colors/meliora.kak
@@ -23,7 +23,7 @@ declare-option str secondary_white "rgb:C2B4A8"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default "%opt{light_grey},black@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_comment "%opt{comment}"
@@ -114,7 +114,7 @@ set-face global ts_type "%opt{secondary_white}"
 set-face global ts_type_builtin ts_type
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant ts_type_enum
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin ts_variable
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member ts_variable_other

--- a/colors/mellow.kak
+++ b/colors/mellow.kak
@@ -50,7 +50,7 @@ set-face global ts_diff_delta "%opt{bright_blue}"
 set-face global ts_diff_delta_moved ts_diff_delta
 set-face global ts_diff_minus "%opt{bright_red}"
 set-face global ts_diff_plus "%opt{bright_green}"
-set-face global ts_function "white"
+set-face global ts_function "bright-white"
 set-face global ts_function_builtin "%opt{bright_blue}"
 set-face global ts_function_macro "%opt{bright_cyan}"
 set-face global ts_function_method ts_function
@@ -125,5 +125,5 @@ set-face global ts_type_enum_variant "magenta"
 set-face global ts_variable "%opt{fg}"
 set-face global ts_variable_builtin "%opt{bright_blue}"
 set-face global ts_variable_other ts_variable
-set-face global ts_variable_other_member "white"
+set-face global ts_variable_other_member "bright-white"
 set-face global ts_variable_parameter "cyan"

--- a/colors/nightfox.kak
+++ b/colors/nightfox.kak
@@ -128,7 +128,7 @@ set-face global ts_type "yellow"
 set-face global ts_type_builtin "%opt{cyan_bright}"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant "%opt{orange_bright}"
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin "red"
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "%opt{fg2}"

--- a/colors/noctis-bordo.kak
+++ b/colors/noctis-bordo.kak
@@ -56,7 +56,7 @@ set-face global ts_keyword_control_exception ts_keyword_control
 set-face global ts_keyword_control_import ts_keyword_control
 set-face global ts_keyword_control_repeat ts_keyword_control
 set-face global ts_keyword_control_return ts_keyword_control
-set-face global ts_keyword_directive "white"
+set-face global ts_keyword_directive "bright-white"
 set-face global ts_keyword_function ts_keyword
 set-face global ts_keyword_operator "%opt{base0E}+i"
 set-face global ts_keyword_special ts_keyword

--- a/colors/noctis.kak
+++ b/colors/noctis.kak
@@ -19,11 +19,11 @@ declare-option str light_blue "rgb:87EFFF"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default "%opt{autocomp_green},%opt{dark_green}@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "gray+i"
+set-face global ts_comment "bright-black+i"
 set-face global ts_comment_block ""
 set-face global ts_comment_line ""
 set-face global ts_constant "bright-blue+b"

--- a/colors/onedark.kak
+++ b/colors/onedark.kak
@@ -17,11 +17,11 @@ declare-option str linenr "rgb:4B5263"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",black@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "bright-gray+i"
+set-face global ts_comment "white+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "cyan"

--- a/colors/onedarker.kak
+++ b/colors/onedarker.kak
@@ -17,11 +17,11 @@ declare-option str linenr "rgb:282C34"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",black@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "bright-gray+i"
+set-face global ts_comment "white+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "%opt{gold}"
@@ -38,7 +38,7 @@ set-face global ts_diff_delta "%opt{gold}"
 set-face global ts_diff_delta_moved ts_diff_delta
 set-face global ts_diff_minus "red"
 set-face global ts_diff_plus "green"
-set-face global ts_function "white"
+set-face global ts_function "bright-white"
 set-face global ts_function_builtin "blue"
 set-face global ts_function_macro "%opt{purple}"
 set-face global ts_function_method ts_function
@@ -55,7 +55,7 @@ set-face global ts_keyword_control_repeat ts_keyword_control
 set-face global ts_keyword_control_return ts_keyword_control
 set-face global ts_keyword_directive "%opt{purple}"
 set-face global ts_keyword_function ts_keyword
-set-face global ts_keyword_operator "white"
+set-face global ts_keyword_operator "bright-white"
 set-face global ts_keyword_special ts_keyword
 set-face global ts_keyword_storage ts_keyword
 set-face global ts_keyword_storage_modifier ts_keyword_storage
@@ -74,8 +74,8 @@ set-face global ts_markup_heading_6 ts_markup_heading
 set-face global ts_markup_heading_marker ts_markup_heading
 set-face global ts_markup_italic "%opt{purple}+i"
 set-face global ts_markup_link ts_markup
-set-face global ts_markup_link_label "white"
-set-face global ts_markup_link_text "white"
+set-face global ts_markup_link_label "bright-white"
+set-face global ts_markup_link_text "bright-white"
 set-face global ts_markup_link_uri ts_markup_link
 set-face global ts_markup_link_url "blue+u"
 set-face global ts_markup_list ts_markup
@@ -85,11 +85,11 @@ set-face global ts_markup_list_unchecked ts_markup_list
 set-face global ts_markup_list_unnumbered ts_markup_list
 set-face global ts_markup_quote "yellow"
 set-face global ts_markup_raw ts_markup
-set-face global ts_markup_raw_block "white"
+set-face global ts_markup_raw_block "bright-white"
 set-face global ts_markup_raw_inline "green"
 set-face global ts_markup_strikethrough "+s"
 set-face global ts_namespace "%opt{purple}"
-set-face global ts_operator "white"
+set-face global ts_operator "bright-white"
 set-face global ts_punctuation_bracket ts_punctuation
 set-face global ts_punctuation_delimiter ts_punctuation
 set-face global ts_punctuation_special ts_punctuation
@@ -108,7 +108,7 @@ set-face global ts_type "yellow"
 set-face global ts_type_builtin ts_type
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant ts_type_enum
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin "red"
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "blue"

--- a/colors/onelight.kak
+++ b/colors/onelight.kak
@@ -21,7 +21,7 @@ declare-option str grey_100 "rgb:F2F2F2"
 
 # Standard Kakoune
 set-face global Default default,default,default
-set-face global Default ",white@Default"
+set-face global Default ",bright-white@Default"
 set-face global Default "black@Default"
 
 # kak-tree-sitter

--- a/colors/poimandres-storm.kak
+++ b/colors/poimandres-storm.kak
@@ -12,7 +12,7 @@ declare-option str black "rgb:101010"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",%opt{bg}@Default"
-set-face global Default "gray@Default"
+set-face global Default "bright-black@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "%opt{desaturatedBlue}+i"
@@ -48,7 +48,7 @@ set-face global ts_keyword_control_exception ts_keyword_control
 set-face global ts_keyword_control_import ts_keyword_control
 set-face global ts_keyword_control_repeat ts_keyword_control
 set-face global ts_keyword_control_return ts_keyword_control
-set-face global ts_keyword_directive "gray"
+set-face global ts_keyword_directive "bright-black"
 set-face global ts_keyword_function ts_keyword
 set-face global ts_keyword_operator "%opt{desaturatedBlue}"
 set-face global ts_keyword_special ts_keyword
@@ -85,7 +85,7 @@ set-face global ts_markup_raw_inline ts_markup_raw
 set-face global ts_markup_strikethrough "+is"
 set-face global ts_namespace "%opt{lightBlue}"
 set-face global ts_operator "%opt{desaturatedBlue}"
-set-face global ts_punctuation "gray"
+set-face global ts_punctuation "bright-black"
 set-face global ts_punctuation_bracket "%opt{desaturatedBlue}"
 set-face global ts_punctuation_delimiter ts_punctuation
 set-face global ts_punctuation_special ts_punctuation

--- a/colors/poimandres.kak
+++ b/colors/poimandres.kak
@@ -26,7 +26,7 @@ declare-option str transparent "rgb:00000000"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default ",%opt{bg}@Default"
-set-face global Default "gray@Default"
+set-face global Default "bright-black@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "%opt{desaturatedBlue}+i"
@@ -62,7 +62,7 @@ set-face global ts_keyword_control_exception ts_keyword_control
 set-face global ts_keyword_control_import ts_keyword_control
 set-face global ts_keyword_control_repeat ts_keyword_control
 set-face global ts_keyword_control_return ts_keyword_control
-set-face global ts_keyword_directive "gray"
+set-face global ts_keyword_directive "bright-black"
 set-face global ts_keyword_function ts_keyword
 set-face global ts_keyword_operator "%opt{desaturatedBlue}"
 set-face global ts_keyword_special ts_keyword
@@ -99,7 +99,7 @@ set-face global ts_markup_raw_inline ts_markup_raw
 set-face global ts_markup_strikethrough "+is"
 set-face global ts_namespace "%opt{lightBlue}"
 set-face global ts_operator "%opt{desaturatedBlue}"
-set-face global ts_punctuation "gray"
+set-face global ts_punctuation "bright-black"
 set-face global ts_punctuation_bracket "%opt{desaturatedBlue}"
 set-face global ts_punctuation_delimiter ts_punctuation
 set-face global ts_punctuation_special ts_punctuation

--- a/colors/pop-dark.kak
+++ b/colors/pop-dark.kak
@@ -131,4 +131,4 @@ set-face global ts_variable "%opt{greyT}"
 set-face global ts_variable_builtin "%opt{blueL}"
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "%opt{orangeH}"
-set-face global ts_variable_parameter "white"
+set-face global ts_variable_parameter "bright-white"

--- a/colors/rasmus.kak
+++ b/colors/rasmus.kak
@@ -35,7 +35,7 @@ set-face global ts_attribute "cyan"
 set-face global ts_comment "%opt{gray05}+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
-set-face global ts_constant "white"
+set-face global ts_constant "bright-white"
 set-face global ts_constant_builtin ts_constant
 set-face global ts_constant_builtin_boolean ts_constant_builtin
 set-face global ts_constant_character ts_constant
@@ -49,7 +49,7 @@ set-face global ts_diff_delta "%opt{bright_cyan}"
 set-face global ts_diff_delta_moved ts_diff_delta
 set-face global ts_diff_minus "%opt{bright_red}"
 set-face global ts_diff_plus "%opt{bright_green}"
-set-face global ts_function "white"
+set-face global ts_function "bright-white"
 set-face global ts_function_builtin "blue"
 set-face global ts_function_macro "blue"
 set-face global ts_function_method ts_function
@@ -76,7 +76,7 @@ set-face global ts_keyword_storage_type ts_keyword_storage
 set-face global ts_label "yellow"
 set-face global ts_markup_bold "+b"
 set-face global ts_markup_heading ts_markup
-set-face global ts_markup_heading_1 "white+b"
+set-face global ts_markup_heading_1 "bright-white+b"
 set-face global ts_markup_heading_2 "%opt{gray07}+b"
 set-face global ts_markup_heading_3 "%opt{gray07}+b"
 set-face global ts_markup_heading_4 "%opt{gray07}+b"
@@ -121,8 +121,8 @@ set-face global ts_type "%opt{bright_white}"
 set-face global ts_type_builtin "magenta"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant "magenta"
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin "%opt{bright_blue}"
 set-face global ts_variable_other ts_variable
-set-face global ts_variable_other_member "white"
+set-face global ts_variable_other_member "bright-white"
 set-face global ts_variable_parameter "%opt{bright_white}"

--- a/colors/starlight.kak
+++ b/colors/starlight.kak
@@ -66,7 +66,7 @@ set-face global ts_keyword_storage_modifier_ref ts_keyword_storage_modifier
 set-face global ts_keyword_storage_type ts_keyword_storage
 set-face global ts_label "blue"
 set-face global ts_markup_bold "magenta+b"
-set-face global ts_markup_heading "white+b"
+set-face global ts_markup_heading "bright-white+b"
 set-face global ts_markup_heading_1 ts_markup_heading
 set-face global ts_markup_heading_2 ts_markup_heading
 set-face global ts_markup_heading_3 ts_markup_heading
@@ -90,7 +90,7 @@ set-face global ts_markup_raw "green"
 set-face global ts_markup_raw_block ts_markup_raw
 set-face global ts_markup_raw_inline ts_markup_raw
 set-face global ts_markup_strikethrough "red"
-set-face global ts_namespace "white"
+set-face global ts_namespace "bright-white"
 set-face global ts_operator "blue"
 set-face global ts_punctuation "%opt{punct}"
 set-face global ts_punctuation_bracket ts_punctuation
@@ -112,7 +112,7 @@ set-face global ts_type "cyan"
 set-face global ts_type_builtin ts_type
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant ts_type_enum
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin "blue"
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "magenta"

--- a/colors/term16-dark.kak
+++ b/colors/term16-dark.kak
@@ -7,7 +7,7 @@ set-face global Default "@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "bright-yellow"
-set-face global ts_comment "bright-gray+id"
+set-face global ts_comment "white+id"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "bright-yellow+bd"
@@ -94,7 +94,7 @@ set-face global ts_type "blue"
 set-face global ts_type_builtin "blue+b"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant "bright-magenta+d"
-set-face global ts_variable "white"
+set-face global ts_variable "bright-white"
 set-face global ts_variable_builtin ts_variable
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "bright-green"

--- a/colors/term16-light.kak
+++ b/colors/term16-light.kak
@@ -7,7 +7,7 @@ set-face global Default "@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "gray+id"
+set-face global ts_comment "bright-black+id"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "yellow+b"

--- a/colors/ttox.kak
+++ b/colors/ttox.kak
@@ -18,7 +18,7 @@ set-face global ts_constant_macro ts_constant
 set-face global ts_constant_numeric ts_constant
 set-face global ts_constant_numeric_float ts_constant_numeric
 set-face global ts_constant_numeric_integer ts_constant_numeric
-set-face global ts_diff_delta "gray"
+set-face global ts_diff_delta "bright-black"
 set-face global ts_diff_delta_moved ts_diff_delta
 set-face global ts_diff_minus "red"
 set-face global ts_diff_plus "green"

--- a/colors/voxed.kak
+++ b/colors/voxed.kak
@@ -21,7 +21,7 @@ declare-option str gruvgreen "rgb:B8BB26"
 # Standard Kakoune
 set-face global Default default,default,default
 set-face global Default "rgb:25262B,rgb:1F1F21@Default"
-set-face global Default "white@Default"
+set-face global Default "bright-white@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "%opt{buff}"
@@ -94,7 +94,7 @@ set-face global ts_markup_raw_inline ts_markup_raw
 set-face global ts_markup_strikethrough "+s"
 set-face global ts_namespace "blue"
 set-face global ts_operator "%opt{greenish}"
-set-face global ts_punctuation "white"
+set-face global ts_punctuation "bright-white"
 set-face global ts_punctuation_bracket ts_punctuation
 set-face global ts_punctuation_delimiter "%opt{functionish}"
 set-face global ts_punctuation_special ts_punctuation
@@ -115,7 +115,7 @@ set-face global ts_type_builtin "%opt{functionish}"
 set-face global ts_type_enum ts_type
 set-face global ts_type_enum_variant ts_type_enum
 set-face global ts_variable "%opt{tan}"
-set-face global ts_variable_builtin "white"
+set-face global ts_variable_builtin "bright-white"
 set-face global ts_variable_other ts_variable
 set-face global ts_variable_other_member "%opt{bsienna}"
 set-face global ts_variable_parameter "%opt{parameters}"

--- a/colors/yellowed.kak
+++ b/colors/yellowed.kak
@@ -38,7 +38,7 @@ set-face global ts_constant_numeric_float ts_constant_numeric
 set-face global ts_constant_numeric_integer ts_constant_numeric
 set-face global ts_constructor "%opt{text}+b"
 set-face global ts_diff_delta "blue"
-set-face global ts_diff_delta_moved "gray"
+set-face global ts_diff_delta_moved "bright-black"
 set-face global ts_diff_minus "red"
 set-face global ts_diff_plus "green"
 set-face global ts_function "%opt{text}+b"

--- a/colors/zed-onedark.kak
+++ b/colors/zed-onedark.kak
@@ -23,7 +23,7 @@ set-face global Default "%opt{ui_text}@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "yellow"
-set-face global ts_comment "bright-gray+i"
+set-face global ts_comment "white+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "yellow"

--- a/colors/zed-onelight.kak
+++ b/colors/zed-onelight.kak
@@ -28,7 +28,7 @@ set-face global Default "%opt{ui_text}@Default"
 
 # kak-tree-sitter
 set-face global ts_attribute "green"
-set-face global ts_comment "bright-gray+i"
+set-face global ts_comment "white+i"
 set-face global ts_comment_block ts_comment
 set-face global ts_comment_line ts_comment
 set-face global ts_constant "green"

--- a/converter.py
+++ b/converter.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import shutil
+
 import tomllib
 
 from hx_ts_scopes import hx_ts_scopes
@@ -113,32 +114,30 @@ def scope_value(scope):
 
 
 def color(c):
-    hx_ansi = set(
-        [
-            "black",
-            "blue",
-            "cyan",
-            "default",
-            "gray",
-            "green",
-            "magenta",
-            "red",
-            "white",
-            "yellow",
-            "light-blue",
-            "light-cyan",
-            "light-gray",
-            "light-green",
-            "light-magenta",
-            "light-red",
-            "light-yellow",
-        ]
-    )
+    hx_ansi = {
+        "black": "black",
+        "gray": "bright-black",
+        "light-gray": "white",
+        "white": "bright-white",
+        "blue": "blue",
+        "cyan": "cyan",
+        "default": "default",
+        "green": "green",
+        "magenta": "magenta",
+        "red": "red",
+        "yellow": "yellow",
+        "light-blue": "bright-blue",
+        "light-cyan": "bright-cyan",
+        "light-green": "bright-green",
+        "light-magenta": "bright-magenta",
+        "light-red": "bright-red",
+        "light-yellow": "bright-yellow",
+    }
     if c.startswith("#"):
         return c.upper().replace("#", "rgb:")
     else:
         if c in hx_ansi:
-            return c.replace("light", "bright")
+            return hx_ansi.get(c)
         elif c != "":
             c = c.replace(".", "_").replace("-", "_")
             return f"%opt{{{c}}}"


### PR DESCRIPTION
Fixed https://github.com/igor-ramazanov/kak-tree-sitter-helix/issues/5

New mapping is:
1. `gray`: `bright-black`
1. `light-gray`: `white`
1. `white`: `bright-white`