### PR TITLE
Build `kak-tree-sitter` using Nix flakes with Helix grammars and queries

### DIFF
--- a/9fccddd14b66a63c2c93d4069fee6a51155e5a9e.patch
+++ b/9fccddd14b66a63c2c93d4069fee6a51155e5a9e.patch
@@ -1,0 +1,113 @@
+diff --git a/kak-tree-sitter-config/src/lib.rs b/kak-tree-sitter-config/src/lib.rs
+index 03ca041..cebbc4d 100644
+--- a/kak-tree-sitter-config/src/lib.rs
++++ b/kak-tree-sitter-config/src/lib.rs
+@@ -25,7 +25,7 @@ pub enum ConfigError {
+ }
+ 
+ impl ConfigError {
+-  pub fn missing_opt(opt: impl Into<String>) -> Self {
++  fn missing_opt(opt: impl Into<String>) -> Self {
+     Self::MissingOption { opt: opt.into() }
+   }
+ }
+@@ -42,23 +42,10 @@ pub struct Config {
+ }
+ 
+ impl Config {
+-  /// Load the configuration from a given path.
+-  pub fn load(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
+-    let path = path.as_ref();
+-    let content = fs::read_to_string(path).map_err(|err| ConfigError::CannotReadConfig {
+-      path: path.to_owned(),
+-      err,
+-    })?;
+-
+-    toml::from_str(&content).map_err(|err| ConfigError::CannotParseConfig {
+-      err: err.to_string(),
+-    })
+-  }
+-
+   /// Default configuration using the `default-config.toml` file.
+   const DEFAULT_CONFIG_CONTENT: &'static str = include_str!("../../default-config.toml");
+ 
+-  pub fn load_default_config() -> Result<Self, ConfigError> {
++  fn load_default_config() -> Result<Self, ConfigError> {
+     log::debug!("loading default configuration");
+ 
+     toml::from_str(Self::DEFAULT_CONFIG_CONTENT).map_err(|err| ConfigError::CannotParseConfig {
+@@ -83,7 +70,7 @@ impl Config {
+   }
+ 
+   /// Merge the config with a user-provided one.
+-  pub fn merge_user_config(&mut self, user_config: UserConfig) -> Result<(), ConfigError> {
++  fn merge_user_config(&mut self, user_config: UserConfig) -> Result<(), ConfigError> {
+     if let Some(user_highlight) = user_config.highlight {
+       self.highlight.merge_user_config(user_highlight);
+     }
+@@ -119,6 +106,26 @@ pub struct LanguagesConfig {
+ }
+ 
+ impl LanguagesConfig {
++  /// Get the directory with built-in grammars and queries relative to the binary.
++  fn get_builtin_dir() -> Option<PathBuf> {
++    std::env::current_exe()
++      .ok()?
++      .parent()?
++      .parent()
++      .map(|dir| dir.join("share/kak-tree-sitter"))
++  }
++
++  /// First, try to use `from_data_dir` if absent, use `builtin`.
++  fn fallback(from_data_dir: Option<PathBuf>, builtin: Option<PathBuf>) -> Option<PathBuf> {
++    match from_data_dir {
++      Some(path) => match path.try_exists() {
++        Ok(true) => Some(path),
++        Ok(false) | Err(_) => builtin,
++      },
++      None => builtin,
++    }
++  }
++
+   fn merge_user_config(&mut self, user_config: UserLanguagesConfig) -> Result<(), ConfigError> {
+     for (lang, user_config) in user_config.language {
+       if let Some(config) = self.language.get_mut(&lang) {
+@@ -140,21 +147,22 @@ impl LanguagesConfig {
+     self.language.get(lang.as_ref())
+   }
+ 
+-  /// Get the directory where all grammars live in.
+-  pub fn get_grammars_dir() -> Option<PathBuf> {
+-    dirs::data_dir().map(|dir| dir.join("kak-tree-sitter/grammars"))
+-  }
+-
+   /// Get the grammar path for a given language.
+   pub fn get_grammar_path(lang: impl AsRef<str>) -> Option<PathBuf> {
+     let lang = lang.as_ref();
+-    dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/grammars/{lang}.so")))
++    let builtin = Self::get_builtin_dir().map(|dir| dir.join(format!("grammars/{lang}.so")));
++    let from_data_dir =
++      dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/grammars/{lang}.so")));
++    Self::fallback(from_data_dir, builtin)
+   }
+ 
+   /// Get the queries directory for a given language.
+   pub fn get_queries_dir(lang: impl AsRef<str>) -> Option<PathBuf> {
+     let lang = lang.as_ref();
+-    dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/queries/{lang}")))
++    let builtin = Self::get_builtin_dir().map(|dir| dir.join(format!("queries/{lang}")));
++    let from_data_dir =
++      dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/queries/{lang}")));
++    Self::fallback(from_data_dir, builtin)
+   }
+ }
+ 
+@@ -411,7 +419,7 @@ pub struct UserConfig {
+ 
+ impl UserConfig {
+   /// Load the config from the default user location (XDG).
+-  pub fn load_from_xdg() -> Result<Self, ConfigError> {
++  fn load_from_xdg() -> Result<Self, ConfigError> {
+     log::debug!("loading user configuration");
+ 
+     let dir = dirs::config_dir().ok_or(ConfigError::NoConfigDir)?;

--- a/flake.lock
+++ b/flake.lock
@@ -19,6 +19,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1710570073,
+        "narHash": "sha256-SfoPz6L/WjZ9uZGT1xsPX3uzxJXO32uS4V+i6lpgXL8=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b06c3b4110bfb731d8b84b35cc5f7e00e63b37ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -73,22 +94,43 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703438236,
-        "narHash": "sha256-aqVBq1u09yFhL7bj1/xyUeJjzr92fXVvQSSEx6AdB1M=",
-        "path": "/nix/store/5acdh8xyry0kdvp6xla2hw7wf3zkphkl-source",
-        "rev": "5f64a12a728902226210bf01d25ec6cbb9d9265b",
-        "type": "path"
+        "lastModified": 1710534455,
+        "narHash": "sha256-huQT4Xs0y4EeFKn2BTBVYgEwJSv8SDlm82uWgMnCMmI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9af9c1c87ed3e3ed271934cb896e0cdd33dae212",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
         "devshell": "devshell",
+        "fenix": "fenix",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1710512753,
+        "narHash": "sha256-9KsYA6RjSDIqeAEZvbVTr46xD1f5j42Vnpml9GcoGgM=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "d7ec7a5441190b4fde399b2ac3a8d9daaf062e1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/gen-grammars.nix
+++ b/gen-grammars.nix
@@ -1,0 +1,121 @@
+# Fetch and build grammars from https://github.com/helix-editor/helix/languages.toml.
+# The code is borrowed and reworked from: https://github.com/helix-editor/helix/blob/85fce2f5b6c9f35ab9d3361f3933288a28db83d4/grammars.nix.
+{helix}: {
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  ...
+}: let
+  buildGrammar = grammar:
+    stdenv.mkDerivation {
+      # See: https://github.com/NixOS/nixpkgs/blob/fbdd1a7c0bc29af5325e0d7dd70e804a972eb465/pkgs/development/tools/parsing/tree-sitter/grammar.nix.
+      pname = "tree-sitter-${grammar.name}";
+      version = grammar.source.rev;
+
+      src = let
+        isGitHubGrammar = grammar: lib.hasPrefix "https://github.com" grammar.source.git;
+        sourceGitHub = let
+          match = builtins.match "https://github\.com/([^/]*)/([^/]*)/?" grammar.source.git;
+          owner = builtins.elemAt match 0;
+          repo = builtins.elemAt match 1;
+        in
+          builtins.fetchTree {
+            inherit (grammar.source) rev;
+            inherit owner repo;
+            type = "github";
+          };
+        sourceGit = builtins.fetchTree {
+          type = "git";
+          url = grammar.source.git;
+          rev = grammar.source.rev;
+          ref = grammar.source.ref or "HEAD";
+          shallow = true;
+        };
+      in
+        if isGitHubGrammar grammar
+        then sourceGitHub
+        else sourceGit;
+
+      sourceRoot =
+        if builtins.hasAttr "subpath" grammar.source
+        then "source/${grammar.source.subpath}"
+        else "source";
+
+      dontConfigure = true;
+
+      FLAGS = [
+        "-Isrc"
+        "-g"
+        "-O3"
+        "-fPIC"
+        "-fno-exceptions"
+        "-Wl,-z,relro,-z,now"
+      ];
+
+      NAME = grammar.name;
+
+      buildPhase = ''
+        runHook preBuild
+
+        if [[ -e src/scanner.cc ]]; then
+          $CXX -c src/scanner.cc -o scanner.o $FLAGS
+        elif [[ -e src/scanner.c ]]; then
+          $CC -c src/scanner.c -o scanner.o $FLAGS
+        fi
+
+        $CC -c src/parser.c -o parser.o $FLAGS
+        $CXX -shared -o $NAME.so *.o
+
+        ls -al
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir $out
+        mv $NAME.so $out/
+        runHook postInstall
+      '';
+
+      # Strip failed on darwin: strip: error: symbols referenced by indirect symbol table entries that can't be stripped
+      fixupPhase = lib.optionalString stdenv.isLinux ''
+        runHook preFixup
+        $STRIP $out/$NAME.so
+        runHook postFixup
+      '';
+    };
+in
+  stdenv.mkDerivation rec {
+    pname = "consolidated-grammars";
+    version = helix.version;
+
+    src = helix.repo;
+
+    dontUnpack = true;
+    dontPatch = true;
+    dontConfigure = true;
+
+    buildPhase = let
+      languagesConfig = builtins.fromTOML (builtins.readFile "${src}/languages.toml");
+      isGitGrammar = grammar:
+        builtins.hasAttr "source" grammar
+        && builtins.hasAttr "git" grammar.source
+        && builtins.hasAttr "rev" grammar.source;
+      gitGrammars = builtins.filter isGitGrammar languagesConfig.grammar;
+      builtGrammars =
+        builtins.map (grammar: {
+          inherit (grammar) name;
+          value = buildGrammar grammar;
+        })
+        gitGrammars;
+      grammarLinks =
+        lib.mapAttrsToList
+        (name: artifact: "ln -s ${artifact}/${name}.so $out/grammars/${name}.so")
+        (lib.filterAttrs (n: v: lib.isDerivation v) (builtins.listToAttrs builtGrammars));
+    in ''
+      mkdir -p $out/grammars
+      ${builtins.concatStringsSep "\n" grammarLinks}
+      ln -s ${src}/runtime/queries $out/queries
+    '';
+  }


### PR DESCRIPTION
* Basically, https://github.com/hadronized/kak-tree-sitter/pull/200 moved to this repo.
* Had to add the patch to use embedded grammars and queries.
* `kak-tree-sitter` still loads the default config, but it has no function.