### PR TITLE
Update to kak-tree-sitter 1.1.2-dev

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,24 +1,5 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1705332421,
-        "narHash": "sha256-USpGLPme1IuqG78JNqSaRabilwkCyHmVWY0M9vYyqEA=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "83cb93d6d063ad290beee669f4badf9914cc16ec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -45,24 +26,6 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
         "lastModified": 1705309234,
         "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
@@ -77,22 +40,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1704161960,
-        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1710534455,
         "narHash": "sha256-huQT4Xs0y4EeFKn2BTBVYgEwJSv8SDlm82uWgMnCMmI=",
@@ -110,10 +57,9 @@
     },
     "root": {
       "inputs": {
-        "devshell": "devshell",
         "fenix": "fenix",
-        "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
@@ -134,21 +80,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "kak-tree-sitter + helix = ❤";
 
   inputs = {
-    devshell.url = "github:numtide/devshell";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
     fenix.url = "github:nix-community/fenix";
     flake-utils.url = "github:numtide/flake-utils";
@@ -10,8 +9,7 @@
   };
 
   outputs =
-    { devshell
-    , fenix
+    { fenix
     , flake-utils
     , nixpkgs
     , ...
@@ -20,7 +18,7 @@
     let
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [ devshell.overlays.default fenix.overlays.default ];
+        overlays = [ fenix.overlays.default ];
       };
 
       helix = {
@@ -41,11 +39,11 @@
         rustPlatform.buildRustPackage rec {
           version = (builtins.fromTOML (builtins.readFile "${src}/kak-tree-sitter/Cargo.toml")).package.version;
           pname = "kak-tree-sitter";
-          src = pkgs.fetchFromSourcehut {
-            owner = "~hadronized";
+          src = pkgs.fetchFromGitHub {
+            owner = "hadronized";
             repo = "kak-tree-sitter";
-            rev = "1bbd49b74e1224d860310426d92c5d505f5e9da3";
-            hash = "sha256-VNfegTKypCRZ6c4kl49jcgHpcKghN4z9906gWMlkih0=";
+            rev = "955b31df81532fc67a2e56279457d587f1d615fb";
+            hash = "sha256-LuFI0tRtZZ9C6xKRUbSzE/oI8Z7djo7RvF5xM8776gI=";
           };
           cargoLock = {
             lockFile = "${src}/Cargo.lock";
@@ -70,16 +68,6 @@
       apps.default = {
         type = "app";
         program = "${kts-package}/bin/kak-tree-sitter";
-      };
-      devShell = pkgs.devshell.mkShell {
-        name = "kak-tree-sitter-helix";
-        motd = "Entered the kak-tree-sitter-helix development environment";
-        packages =
-          let
-            rust = [ (pkgs.fenix.stable.withComponents [ "cargo" "clippy" "rust-analyzer" "rustfmt" "rust-src" ]) ];
-            python = [ (pkgs.python311.withPackages (p: [ p.flake8 p.python-lsp-server p.python-lsp-black ])) ];
-          in
-          rust ++ python;
       };
       homeManagerModules.kak-tree-sitter-helix =
         { config

--- a/nix/gen-grammars.nix
+++ b/nix/gen-grammars.nix
@@ -46,7 +46,6 @@ let
 
       FLAGS = [
         "-Isrc"
-        "-g"
         "-O3"
         "-fPIC"
         "-fno-exceptions"


### PR DESCRIPTION
This PR makes some changes to keep up with the development of kak-tree-sitter, since the repository is now hosted on GitHub.

Things done:
1. Now kak-tree-sitter is being sourced from [GitHub master branch](https://github.com/hadronized/kak-tree-sitter).

2.  Updated README to include how-to install for home-manager as a [standalone option](https://nix-community.github.io/home-manager/index.xhtml#sec-install-standalone), and also updated info about kakoune config.

3.  Also I did remove the devshell option from flake, because, in my opinion, this flake is mainly used for home-manager and is less suitable for development shell (but it's easy to revert back if this change is overkill).

4. Removed debug info when building tree-sitter parsers.