### PR TITLE
nixosModule, homeMananagerModule: link as `colors/kak-tree-sitter-helix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This will:
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
     in {
-      nixosConfigurations."my_machine_name" = nixpkgs.lib.nixosSystem {
+      nixosConfigurations.MY_PC_HOSTNAME = nixpkgs.lib.nixosSystem {
         inherit system;
         modules = [ 
           kak-tree-sitter-helix.nixosModules.${system}.kak-tree-sitter-helix
@@ -122,7 +122,7 @@ This will:
 {
   programs.kak-tree-sitter-helix = {
     enable = true;
-    # This will link themes directory directly from the /nix/store to /home/my_username/.config/kak/color using systemd tmpfiles
+    # This will link themes directory directly from the /nix/store as /home/my_username/.config/kak/color/kak-tree-sitter-helix using systemd tmpfiles
     user = "my_username";
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,7 @@
 
         config = lib.mkIf config.programs.kak-tree-sitter-helix.enable {
           home.packages = [kak-tree-sitter];
-          xdg.configFile."kak/colors".source = "${kak-tree-sitter-themes}/colors";
+          xdg.configFile."kak/colors/kak-tree-sitter-helix".source = "${kak-tree-sitter-themes}/colors";
         };
       };
 
@@ -137,7 +137,7 @@
         config = lib.mkIf cfg.enable {
           environment.systemPackages = [kak-tree-sitter];
           systemd.user.tmpfiles.users.${cfg.user}.rules = [
-            "L+ /home/${cfg.user}/.config/kak/colors 0444 - - - ${kak-tree-sitter-themes}/colors"
+            "L+ /home/${cfg.user}/.config/kak/colors/kak-tree-sitter-helix 0444 - - - ${kak-tree-sitter-themes}/colors"
           ];
         };
       };


### PR DESCRIPTION
Instead of ~/.config/kak/colors to avoid clashing with existing themes